### PR TITLE
stubborn connect_async

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-shadow"
-version = "0.2.1"
+version = "0.2.2"
 license = "Apache-2.0"
 authors = ["Karim Agha <karim.dev@gmail.com>"]
 description = "Synchronized shadow state of Solana programs available for off-chain processing."

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -31,7 +31,7 @@ pub(crate) type SubRequestCall =
 /// for now it is set to 64, which gives us about 30 seconds on Solana
 /// as there can be an update at most once every 400 miliseconds (blocktime)
 const MAX_UPDATES_SUBSCRIBER_LAG: usize = 64;
-const MIN_RECONNECT_EVERY: u64 = 30;
+const MIN_RECONNECT_EVERY: u64 = 5;
 
 #[derive(Clone)]
 pub struct SyncOptions {
@@ -39,6 +39,7 @@ pub struct SyncOptions {
   pub max_lag: Option<usize>,
   pub reconnect_every: Option<Duration>,
   pub rpc_timeout: Duration,
+  pub ws_connect_timeout: Duration,
   pub commitment: CommitmentLevel,
 }
 
@@ -50,6 +51,7 @@ impl Default for SyncOptions {
       reconnect_every: None,
       commitment: CommitmentLevel::Finalized,
       rpc_timeout: Duration::from_secs(12),
+      ws_connect_timeout: Duration::from_secs(12),
     }
   }
 }
@@ -230,6 +232,7 @@ impl BlockchainShadow {
                   }
                 },
                 Ok(None) => {
+                  tracing::error!("unreachable recv_result reached??");
                   unreachable!();
                 },
                 Err(e) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ mod error;
 mod message;
 mod network;
 mod rpc;
+mod stubborn;
 mod sync;
 
 pub use blockchain::{BlockchainShadow, SyncOptions};

--- a/src/stubborn.rs
+++ b/src/stubborn.rs
@@ -1,0 +1,45 @@
+use std::time::Duration;
+
+use tokio::net::TcpStream;
+use tokio_tungstenite::{
+  tungstenite::{self, client::IntoClientRequest, handshake::client::Response},
+  MaybeTlsStream, WebSocketStream,
+};
+use tracing_futures::Instrument;
+use tungstenite::error::Error;
+
+#[tracing::instrument]
+pub async fn connect_async<R>(
+  timeout: Duration,
+  request: R,
+) -> Result<(WebSocketStream<MaybeTlsStream<TcpStream>>, Response), Error>
+where
+  R: std::fmt::Debug + IntoClientRequest + Unpin + Clone,
+{
+  let mut delay = 500;
+  loop {
+    match tokio::time::timeout(
+      timeout,
+      tokio_tungstenite::connect_async(request.clone())
+        .instrument(tracing::info_span!("tungstenite_connect_async")),
+    )
+    .await
+    {
+      Err(e) => {
+        tracing::warn!(
+          error=?e, "timeout while trying to connect to websocket, retrying in {}", delay
+        );
+      }
+      Ok(result) => match result {
+        Ok(r) => {
+          return Ok(r);
+        }
+        Err(e) => {
+          tracing::warn!(error=?e, "websocket connection error, retrying in {}", delay);
+        }
+      },
+    }
+    tokio::time::sleep(Duration::from_millis(delay)).await;
+    delay = std::cmp::min(8000, delay * 2);
+  }
+}


### PR DESCRIPTION
While testing I noticed a stalling due to the `connect_async` hanging in the underlying tungstenite. `src/stubborn` implements a timeout and retry mechanism to ensure active reconnecting.