### PR TITLE
use base64+zstd for account data encoding by default, add ping support and make recv cancellation safe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,35 +1,36 @@
 [package]
-name = "solana-shadow"
-version = "0.2.4"
-license = "Apache-2.0"
 authors = ["Karim Agha <karim.dev@gmail.com>", "Marius Ciubotariu <marius.ciubotariu@gmail.com>"]
 description = "Synchronized shadow state of Solana programs available for off-chain processing."
-keywords = ["blockchain", "solana", "web3"]
-homepage = "https://github.com/hubble-markets/solana-shadow"
-repository = "https://github.com/hubble-markets/solana-shadow"
 edition = "2018"
+homepage = "https://github.com/hubble-markets/solana-shadow"
 include = ["examples/**/*", "src/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
+keywords = ["blockchain", "solana", "web3"]
+license = "Apache-2.0"
+name = "solana-shadow"
+repository = "https://github.com/hubble-markets/solana-shadow"
+version = "0.2.4"
 
 [dependencies]
-bs58 = "0.4"
-borsh = "0.9"
-dashmap = "5.0.0"
-thiserror = "1"
-futures = "0.3"
-tracing = "0.1.29"
 base64 = "0.13"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+borsh = "0.9"
 borsh-derive = "0.9"
+bs58 = "0.4"
+dashmap = "5.0.0"
+futures = "0.3"
 hyper-tls = "0.5.0"
-solana-sdk = "1.8.3"
+serde = {version = "1", features = ["derive"]}
+serde_json = "1"
 solana-client = "1.8.3"
-tokio = { version = "1.13", features = ["full"] }
-tokio-tungstenite = { version = "0.16.1", features = ["native-tls"] }
+solana-sdk = "1.8.3"
+thiserror = "1"
+tokio = {version = "1.13", features = ["full"]}
+tokio-tungstenite = {version = "0.16.1", features = ["native-tls"]}
+tracing = "0.1.29"
 tracing-futures = "0.2.5"
+zstd = "0.9"
 
 [dev-dependencies]
 anyhow = "1"
-rand = "0.8"
 pyth-client = "0.2.2"
-tracing-subscriber = { version = "0.3.1", features = ["env-filter"] }
+rand = "0.8"
+tracing-subscriber = {version = "0.3.1", features = ["env-filter"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["blockchain", "solana", "web3"]
 license = "Apache-2.0"
 name = "solana-shadow"
 repository = "https://github.com/hubble-markets/solana-shadow"
-version = "0.2.4"
+version = "0.2.5"
 
 [dependencies]
 base64 = "0.13"

--- a/src/error.rs
+++ b/src/error.rs
@@ -49,6 +49,9 @@ pub enum Error {
 
   #[error("Internal synchronization error")]
   InternalSynchronizationError(#[from] JoinError),
+
+  #[error("Io Error")]
+  StdIoError(#[from] std::io::Error),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -127,7 +127,7 @@ impl SolanaChangeListener {
       "id": reqid,
       "method": "accountSubscribe",
       "params": [account.to_string(), {
-        "encoding": "jsonParsed",
+        "encoding": "base64+zstd",
         "commitment": self.sync_options.commitment.to_string(),
       }]
     });
@@ -191,7 +191,7 @@ impl SolanaChangeListener {
       "id": reqid,
       "method": "programSubscribe",
       "params": [account.to_string(), {
-        "encoding": "jsonParsed",
+        "encoding": "base64+zstd",
         "commitment": self.sync_options.commitment.to_string()
       }]
     });

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -243,149 +243,15 @@ impl SolanaChangeListener {
   }
 
   #[tracing::instrument(skip(self), level = "debug")]
-  pub async fn recv(&mut self) -> Result<Option<AccountUpdate>> {
+  pub async fn recv(&mut self) -> Result<Message> {
     loop {
       if let Some(ref mut reader) = self.reader {
-        while let Some(msg) = reader.next().await {
-          let message = match msg {
-            Ok(msg) => match msg {
-              Message::Text(text) => Ok(serde_json::from_str(&text)?),
-              Message::Pong(_) => {
-                tracing::trace!("received Pong");
-                continue;
-              }
-              Message::Ping(_) => {
-                if let Some(ref mut writer) = self.writer {
-                  writer.send(Message::Pong(vec![])).await?;
-                  tracing::trace!("received Ping");
-                } else {
-                  warn!("No writer available, cannot reply ping")
-                }
-
-                continue;
-              }
-              _ => Err(Error::UnsupportedRpcFormat),
-            },
+        if let Some(msg) = reader.next().await {
+          match msg {
+            Ok(msg) => return Ok(msg),
             Err(e) => {
               warn!("received ws error from solana: {:?}", &e);
-              Err(Error::WebSocketError(e))
-            }
-          }?;
-
-          tracing::trace!(?message, "received from wss");
-
-          // This message is a JSON-RPC response to a subscription request.
-          // Here we are mapping the request id with the subscription id,
-          // and creating a map of subscription id => pubkey.
-          // This type of message is not relevant to the external callers
-          // of this method, so we keep looping and listening for interesting
-          // notifications.
-          use dashmap::mapref::entry::Entry::{Occupied, Vacant};
-          if let SolanaMessage::Confirmation { id, result, .. } = message {
-            if let Some((_, (sub_request, oneshot))) = self.pending.remove(&id)
-            {
-              self.subscriptions.insert(result, sub_request);
-              match sub_request {
-                SubRequest::Account(account) => {
-                  let (key, acc) =
-                    rpc::get_account(self.client.clone(), account).await?;
-
-                  // only insert entry if we have not received an update
-                  // from our subscription
-                  match self.accounts.entry(key) {
-                    Occupied(mut e) => {
-                      let (_, updated) = e.get();
-
-                      tracing::debug!(?account, ?updated, "occupied branch");
-                      if !updated {
-                        // we update with our RPC values
-                        e.insert((acc.clone(), true));
-                      }
-                    }
-                    Vacant(e) => {
-                      tracing::debug!(?account, "vacant branch");
-                      e.insert((acc, true));
-                    }
-                  }
-
-                  if let Some(oneshot) = oneshot {
-                    let account = self.accounts.get(&key).unwrap().0.clone();
-
-                    tracing::debug!(?account, "oneshot send");
-                    if oneshot.send(vec![account]).is_err() {
-                      tracing::warn!("receiver dropped")
-                    }
-                  }
-                }
-                SubRequest::Program(program_id) => {
-                  // we have a successful program subscription, so now lets get
-                  // all program accounts and add them to our accounts
-                  let accounts: Vec<_> =
-                    rpc::get_program_accounts(self.client.clone(), &program_id)
-                      .await?;
-
-                  // only insert entry if we have not received an update
-                  // from our subscription
-                  let mut result: Vec<Account> = vec![];
-                  for (key, acc) in accounts {
-                    match self.accounts.entry(key) {
-                      Occupied(mut e) => {
-                        let (account, updated) = e.get().clone();
-
-                        tracing::debug!(
-                          ?program_id,
-                          ?account,
-                          ?updated,
-                          "occupied branch"
-                        );
-                        if !updated {
-                          // we update with our RPC values
-                          e.insert((acc.clone(), true));
-                          result.push(acc);
-                        } else {
-                          // value updated over ws subscription
-                          // no need to update, and we push
-                          // the ws value to results to return the
-                          // latest
-                          result.push(account);
-                        }
-                      }
-                      Vacant(e) => {
-                        tracing::debug!(?program_id, ?acc, "vacant branch");
-                        e.insert((acc, true));
-                      }
-                    }
-                  }
-
-                  // return value all the way back to the caller
-                  if let Some(oneshot) = oneshot {
-                    tracing::debug!(?program_id, accounts_len=?result.len(), "oneshot send");
-                    if oneshot.send(result).is_err() {
-                      tracing::warn!("receiver dropped")
-                    }
-                  }
-                }
-                SubRequest::ReconnectAll | SubRequest::Ping => {
-                  // note: we safely ignore these
-                }
-              };
-
-              debug!("created subscripton {} for {:?}", &result, &sub_request);
-            } else {
-              warn!("Unrecognized subscription id: ({}, {})", id, result);
-            }
-          }
-
-          // This is a notification call from Solana telling us to either an
-          // account or a program has changed.
-          if let SolanaMessage::Notification { method, params, .. } = message {
-            match &method[..] {
-              "accountNotification" | "programNotification" => {
-                return Ok(Some(self.account_notification_to_change(params)?));
-              }
-              _ => {
-                warn!("unrecognized notification type: {}", &method);
-              }
+              return Err(Error::WebSocketError(e));
             }
           }
         }
@@ -393,6 +259,147 @@ impl SolanaChangeListener {
         tokio::task::yield_now().await;
       }
     }
+  }
+
+  pub async fn process_message(
+    &mut self,
+    msg: Message,
+  ) -> Result<Option<AccountUpdate>> {
+    let message = match msg {
+      Message::Text(text) => serde_json::from_str(&text)?,
+      Message::Pong(_) => {
+        tracing::trace!("received Pong");
+        return Ok(None);
+      }
+      Message::Ping(_) => {
+        if let Some(ref mut writer) = self.writer {
+          writer.send(Message::Pong(vec![])).await?;
+          tracing::trace!("received Ping");
+        } else {
+          warn!("No writer available, cannot reply ping")
+        }
+        return Ok(None);
+      }
+      _ => Err(Error::UnsupportedRpcFormat)?,
+    };
+
+    tracing::trace!(?message, "received from wss");
+
+    // This message is a JSON-RPC response to a subscription request.
+    // Here we are mapping the request id with the subscription id,
+    // and creating a map of subscription id => pubkey.
+    // This type of message is not relevant to the external callers
+    // of this method, so we keep looping and listening for interesting
+    // notifications.
+    use dashmap::mapref::entry::Entry::{Occupied, Vacant};
+    if let SolanaMessage::Confirmation { id, result, .. } = message {
+      if let Some((_, (sub_request, oneshot))) = self.pending.remove(&id) {
+        self.subscriptions.insert(result, sub_request);
+        match sub_request {
+          SubRequest::Account(account) => {
+            let (key, acc) =
+              rpc::get_account(self.client.clone(), account).await?;
+
+            // only insert entry if we have not received an update
+            // from our subscription
+            match self.accounts.entry(key) {
+              Occupied(mut e) => {
+                let (_, updated) = e.get();
+
+                tracing::debug!(?account, ?updated, "occupied branch");
+                if !updated {
+                  // we update with our RPC values
+                  e.insert((acc.clone(), true));
+                }
+              }
+              Vacant(e) => {
+                tracing::debug!(?account, "vacant branch");
+                e.insert((acc, true));
+              }
+            }
+
+            if let Some(oneshot) = oneshot {
+              let account = self.accounts.get(&key).unwrap().0.clone();
+
+              tracing::debug!(?account, "oneshot send");
+              if oneshot.send(vec![account]).is_err() {
+                tracing::warn!("receiver dropped")
+              }
+            }
+          }
+          SubRequest::Program(program_id) => {
+            // we have a successful program subscription, so now lets get
+            // all program accounts and add them to our accounts
+            let accounts: Vec<_> =
+              rpc::get_program_accounts(self.client.clone(), &program_id)
+                .await?;
+
+            // only insert entry if we have not received an update
+            // from our subscription
+            let mut result: Vec<Account> = vec![];
+            for (key, acc) in accounts {
+              match self.accounts.entry(key) {
+                Occupied(mut e) => {
+                  let (account, updated) = e.get().clone();
+
+                  tracing::debug!(
+                    ?program_id,
+                    ?account,
+                    ?updated,
+                    "occupied branch"
+                  );
+                  if !updated {
+                    // we update with our RPC values
+                    e.insert((acc.clone(), true));
+                    result.push(acc);
+                  } else {
+                    // value updated over ws subscription
+                    // no need to update, and we push
+                    // the ws value to results to return the
+                    // latest
+                    result.push(account);
+                  }
+                }
+                Vacant(e) => {
+                  tracing::debug!(?program_id, ?acc, "vacant branch");
+                  e.insert((acc, true));
+                }
+              }
+            }
+
+            // return value all the way back to the caller
+            if let Some(oneshot) = oneshot {
+              tracing::debug!(?program_id, accounts_len=?result.len(), "oneshot send");
+              if oneshot.send(result).is_err() {
+                tracing::warn!("receiver dropped")
+              }
+            }
+          }
+          SubRequest::ReconnectAll | SubRequest::Ping => {
+            // note: we safely ignore these
+          }
+        };
+
+        debug!("created subscripton {} for {:?}", &result, &sub_request);
+      } else {
+        warn!("Unrecognized subscription id: ({}, {})", id, result);
+      }
+    }
+
+    // This is a notification call from Solana telling us to either an
+    // account or a program has changed.
+    if let SolanaMessage::Notification { method, params, .. } = message {
+      match &method[..] {
+        "accountNotification" | "programNotification" => {
+          return Ok(Some(self.account_notification_to_change(params)?));
+        }
+        _ => {
+          warn!("unrecognized notification type: {}", &method);
+          return Ok(None);
+        }
+      }
+    }
+    return Ok(None);
   }
 
   #[tracing::instrument(skip(self))]


### PR DESCRIPTION
Sorry I squeezed the fixes for #17 #19 and a base64+zstd fix into the same PR.

The first commit in the PR fixes the following problem. 
The jsonParsed encoding won't work if the account data can be parsed by the RPC node. For example, the spl-token account will be actually parsed! The notification from WS becomes 

```json
{
    "jsonrpc": "2.0",
    "method": "accountNotification",
    "params": {
        "result": {
            "context": {
                "slot": 114915064
            },
            "value": {
                "lamports": 2039280,
                "data": {
                    "program": "spl-token",
                    "parsed": {
                        "info": {
                            "isNative": false,
                            "mint": "USDhTjkUXFfigLELiFpbBnpLmEm4aXHvdY2kDSadJDH",
                            "owner": "8dyR4YwFHzh2Pxmgs9TPst5Mu4kkES5tu8w6SuhdEyUG",
                            "state": "initialized",
                            "tokenAmount": {
                                "amount": "5771086231612606",
                                "decimals": 9,
                                "uiAmount": 5771086.231612606,
                                "uiAmountString": "5771086.231612606"
                            }
                        },
                        "type": "account"
                    },
                    "space": 165
                },
                "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
                "executable": false,
                "rentEpoch": 266
            }
        },
        "subscription": 10447
    }
}
```
and cannot be deserialized into the AccountRepresentation struct.

Choosing base64+zstd because it is compressed and should save network bandwidth theoretically (which is the bottleneck).

The rest two commits fixes #17 and #19.